### PR TITLE
Graph: Adding printGraph & Fixing Graph bugs

### DIFF
--- a/Graph.cpp
+++ b/Graph.cpp
@@ -1,51 +1,114 @@
 #include "Graph.h"
 
+/*********************************************************************/
+// Constructor
 Graph::Graph(int n)
 {
+	this->adjList.reserve(n);
+	this->size = n;
 
 	MakeEmptyGraph(n);
 }
 
+/*********************************************************************/
+//Destructor
+Graph:: ~Graph() {
+
+	for (int i = 0; i < this->size; i++) {
+
+		delete adjList[i];
+	}
+}
+
+/*********************************************************************/
 void Graph::MakeEmptyGraph(int n)
 {
-
 	for (int i = 0; i < n; i++)
 	{
-
 		this->adjList.push_back(new List());
 	}
 }
 
+/*********************************************************************/
+/* 
+* Checks if the edge (ver1, ver2) is in the graph.
+*/
 bool Graph::IsAdjacent(int ver1, int ver2)
 {
-
-	return adjList[ver1]->isInList(ver2);
+	return adjList[ver1 - 1]->isInList(ver2 - 1);
 }
 
-List *Graph::GetAdjList(int vertex)
+/*********************************************************************/
+/*
+* GetAdjList returns a *duplication* of the adjList of vertex.
+*/
+List* Graph::GetAdjList(int vertex)
 {
+	List* result = adjList[vertex - 1]->duplicateList();
 
-	return adjList[vertex];
+	return result;
 }
 
+/*********************************************************************/
+/*
+* AddEdge Adds the edge (ver1, ver2) to the graph.
+*/
 void Graph::AddEdge(int ver1, int ver2, int weight)
 {
+	if (!IsAdjacent(ver1, ver2)) {
 
-	adjList[ver1]->insertToTail(ver2, weight);
+		adjList[ver1 - 1]->insertToTail(ver2 - 1, weight);
+
+		AddInvertedEdge(ver2, ver1, weight);
+	}
+
+	// else, the edge is already in the graph -> do nothing.
 }
 
+/*********************************************************************/
+/*
+* AddEdge Adds the edge (ver2, ver1) to the graph.
+*/
+void Graph:: AddInvertedEdge(int ver2, int ver1, int weight) {
+
+	if (!IsAdjacent(ver2, ver1)) {
+
+		adjList[ver2 - 1]->insertToTail(ver1 - 1, weight);
+	}
+
+	// else, the inverted edge is already in the graph -> do nothing.
+}
+
+/*********************************************************************/
+/*
+* Removes the Edges: (ver1, ver2) & (ver2, ver1) from the graph.
+* 
+* ASSUMPTION: if the edge (ver1, ver2) is in the graph, the inverted edge (ver2, ver1) is also in the graph.
+*/
 void Graph::RemoveEdge(int ver1, int ver2)
 {
-
-	if (!(adjList[ver1]->isInList(ver2)))
+	if (!IsAdjacent(ver1, ver2))
 	{
-
-		cout << "The Edge (" << ver1 + 1 << "," << ver2 + 1 << ") is not in the graph" << endl;
+		cout << "The Edge (" << ver1 << "," << ver2 << ") is not in the graph" << endl;
 	}
 	else
 	{
-
-		adjList[ver1]->removeFromList(ver2);
-		adjList[ver2]->removeFromList(ver1);
+		adjList[ver1 - 1]->removeFromList(ver2 - 1);
+		adjList[ver2 - 1]->removeFromList(ver1 - 1);
 	}
 }
+
+/*********************************************************************/
+/*
+* in case a vertex doesn't have edges attached to it, printGraph prints an empty line.
+*/
+void Graph:: printGraph() {
+
+	for (int i = 0; i < size; i++)
+	{
+		adjList[i]->printList(i+1);
+		cout << endl;
+	}
+}
+
+/*********************************************************************/

--- a/Graph.h
+++ b/Graph.h
@@ -7,18 +7,30 @@ using namespace std;
 
 class Graph
 {
+	// The vertexes are 0 - n-1, we will treat them as 1 - n
+	// in case a vertex doesn't have edges attached to it, printGraph prints an empty line.
+
+	// TODO: if Graph size is 0? -> throw exception? / deal with the kelet
+	// TODO: if addEdge(3,3) -> Error?
+	// TODO: adding an existing edge -> Error?
+	// TODO: trying to remove unexisting edge from the graph -> Error?  (We print an error message and continuing as normal
+
 private:
 
 	vector<List*> adjList;
+	int size;
 	
 public:
-	Graph(int n);
+	Graph(int n);  // Constructor
+	~Graph();      // Destructor
 
 	void MakeEmptyGraph(int n);
 	bool IsAdjacent(int ver1, int ver2);
 	List* GetAdjList(int vertex);
 	void AddEdge(int ver1, int ver2, int weight);
+	void AddInvertedEdge(int ver2, int ver1, int weight);
 	void RemoveEdge(int ver1, int ver2);
-};
 
-// The vertexes are 0 - n-1, we will treat them as 1 - n
+	void printGraph();
+	// in case a vertex doesn't have edges attached to it, printGraph prints an empty line.
+};


### PR DESCRIPTION
Functions added:
- printGraph
- Destructor
- AddInvertedEdge

Bugs fixed:
- Vertex syntax was changed
because of an overflow of the vector log size (1 - n  =>  0 - n-1).
- GetAdjList returned the address of the actual List,
Therefore, it could have been changed not from the Graph class.
Solution: function return a duplicate of the original AdjList.